### PR TITLE
Add option to change number of ratings

### DIFF
--- a/djf_surveys/admins/v2/forms.py
+++ b/djf_surveys/admins/v2/forms.py
@@ -21,3 +21,16 @@ class QuestionWithChoicesForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
         self.fields['choices'].widget = InlineChoiceField()
         self.fields['choices'].help_text = _("Click Button Add to adding choice")
+
+class QuestionFormRatings(forms.ModelForm):
+    
+    class Meta:
+        model = Question
+        fields = ['label', 'key', 'choices', 'help_text', 'required']
+    
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields['choices'].widget = forms.NumberInput()
+        self.fields['choices'].help_text = _("")
+        self.fields['choices'].label = _("Number of ratings")
+        self.fields['choices'].initial = 5

--- a/djf_surveys/admins/v2/forms.py
+++ b/djf_surveys/admins/v2/forms.py
@@ -31,6 +31,6 @@ class QuestionFormRatings(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields['choices'].widget = forms.NumberInput()
-        self.fields['choices'].help_text = _("")
+        self.fields['choices'].help_text = _("Must be between 1 and 10")
         self.fields['choices'].label = _("Number of ratings")
         self.fields['choices'].initial = 5

--- a/djf_surveys/admins/v2/forms.py
+++ b/djf_surveys/admins/v2/forms.py
@@ -30,7 +30,7 @@ class QuestionFormRatings(forms.ModelForm):
     
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fields['choices'].widget = forms.NumberInput()
+        self.fields['choices'].widget = forms.NumberInput(attrs={'max':10, 'min':1})
         self.fields['choices'].help_text = _("Must be between 1 and 10")
         self.fields['choices'].label = _("Number of ratings")
         self.fields['choices'].initial = 5

--- a/djf_surveys/admins/v2/views.py
+++ b/djf_surveys/admins/v2/views.py
@@ -15,7 +15,7 @@ from django.http import Http404
 from djf_surveys.app_settings import SURVEYS_ADMIN_BASE_PATH
 from djf_surveys.models import Survey, Question, TYPE_FIELD
 from djf_surveys.mixin import ContextTitleMixin
-from djf_surveys.admins.v2.forms import QuestionForm, QuestionWithChoicesForm
+from djf_surveys.admins.v2.forms import QuestionForm, QuestionWithChoicesForm, QuestionFormRatings
 
 
 @method_decorator(staff_member_required, name='dispatch')
@@ -37,6 +37,8 @@ class AdminCreateQuestionView(ContextTitleMixin, CreateView):
         choices = [TYPE_FIELD.multi_select, TYPE_FIELD.select, TYPE_FIELD.radio]
         if self.type_field_id in choices:
             return QuestionWithChoicesForm
+        elif self.type_field_id == TYPE_FIELD.rating:
+            return QuestionFormRatings
         else:
             return QuestionForm
 
@@ -83,8 +85,17 @@ class AdminUpdateQuestionView(ContextTitleMixin, UpdateView):
         choices = [TYPE_FIELD.multi_select, TYPE_FIELD.select, TYPE_FIELD.radio]
         if self.type_field_id in choices:
             return QuestionWithChoicesForm
+        elif self.type_field_id == TYPE_FIELD.rating:
+            return QuestionFormRatings
         else:
             return QuestionForm
+        
+    def get_object(self):
+        object = super(UpdateView, self).get_object(self.get_queryset())
+        if object.type_field == TYPE_FIELD.rating:
+            if object.choices == None: # use 5 as default for backward compatibility
+                object.choices = 5
+        return object
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/djf_surveys/models.py
+++ b/djf_surveys/models.py
@@ -157,7 +157,9 @@ class Answer(BaseModel):
     @property
     def get_value(self):
         if self.question.type_field == TYPE_FIELD.rating:
-            return create_star(active_star=int(self.value) if self.value else 0)
+            if self.question.choices == None: # use 5 as default for backward compatibility
+                self.question.choices = 5
+            return create_star(active_star=int(self.value) if self.value else 0, num_stars=int(self.question.choices))
         elif self.question.type_field == TYPE_FIELD.url:
             return mark_safe(f'<a href="{self.value}" target="_blank">{self.value}</a>')
         elif self.question.type_field == TYPE_FIELD.radio or self.question.type_field == TYPE_FIELD.select or\

--- a/djf_surveys/summary.py
+++ b/djf_surveys/summary.py
@@ -153,9 +153,10 @@ const data%s = {
 class ChartBarRating(ChartBar):
     height = 200
     rate_avg = 0
+    num_stars = 5
 
     def _base_element_html(self):
-        stars = create_star(active_star=int(self.rate_avg))
+        stars = create_star(active_star=int(self.rate_avg), num_stars=self.num_stars)
         self.element_html = f"""
 <div class="swiper-slide">
     <blockquote class="p-6 border border-gray-100 rounded-lg shadow-lg bg-white">
@@ -192,8 +193,12 @@ class SummaryResponse:
         return pie_chart.render()
     
     def _process_rating_type(self, question: Question):
+        if question.choices == None: # use 5 as default for backward compatibility
+          question.choices = 5
+
         bar_chart = ChartBarRating(chart_id=f"chartbar_{question.id}", chart_name=question.label)
-        labels = ['1', '2', '3', '4', '5']
+        bar_chart.num_stars = int(question.choices)
+        labels = [str(item+1) for item in range(int(question.choices))]
         
         data = []
         for label in labels:

--- a/djf_surveys/templates/djf_surveys/widgets/star_rating.html
+++ b/djf_surveys/templates/djf_surveys/widgets/star_rating.html
@@ -2,9 +2,9 @@
 
 <input type="{{ widget.type }}" name="{{ widget.name }}"{% if widget.value != None %} value="{{ widget.value }}"{% endif %}{% include "django/forms/widgets/attrs.html" %}>
 {% if widget.value != None %}
-    {{ widget.value|create_star:widget.attrs.id }}
+    {% create_star widget.value widget.attrs.id widget.num_ratings %}
 {% else %}
-    {{ "0"|create_star:widget.attrs.id }}
+    {% create_star "0" widget.attrs.id widget.num_ratings %}
 {% endif %}
 
 <script>

--- a/djf_surveys/templatetags/djf_survey_tags.py
+++ b/djf_surveys/templatetags/djf_survey_tags.py
@@ -14,6 +14,6 @@ def get_id_field(field):
     return parse[-1]
 
 
-@register.filter(name='create_star')
-def create_star(number, args):
-    return utils_create_star(active_star=int(number), id_element=args)
+@register.simple_tag
+def create_star(number, id_element, num_stars):
+    return utils_create_star(active_star=int(number), num_stars=num_stars, id_element=id_element)

--- a/djf_surveys/tests.py
+++ b/djf_surveys/tests.py
@@ -1,14 +1,17 @@
 from django.test import TestCase
 from django.core.exceptions import ValidationError
-from djf_surveys.validators import validate_rating
+from djf_surveys.validators import RatingValidator
 
 
 class ValidationForm(TestCase):
     def test_validate_rating(self):
         with self.assertRaises(ValidationError):
-            validate_rating(0, 10)
+            val = RatingValidator(10)
+            val(0)
 
         with self.assertRaises(ValidationError):
-            validate_rating(100, 10)
+            val = RatingValidator(10)
+            val(100)
 
-        validate_rating(2,5)
+        val = RatingValidator(5)
+        val(2)

--- a/djf_surveys/tests.py
+++ b/djf_surveys/tests.py
@@ -6,9 +6,9 @@ from djf_surveys.validators import validate_rating
 class ValidationForm(TestCase):
     def test_validate_rating(self):
         with self.assertRaises(ValidationError):
-            validate_rating(0)
+            validate_rating(0, 10)
 
         with self.assertRaises(ValidationError):
-            validate_rating(100)
+            validate_rating(100, 10)
 
-        validate_rating(2)
+        validate_rating(2,5)

--- a/djf_surveys/utils.py
+++ b/djf_surveys/utils.py
@@ -6,8 +6,8 @@ from django.utils.translation import gettext_lazy as _
 from djf_surveys import models
 
 
-def create_star(active_star: int, id_element: str = '') -> str:
-    inactive_star = 5 - active_star
+def create_star(active_star: int, num_stars: int = 5, id_element: str = '') -> str:
+    inactive_star = num_stars - active_star
     elements = [f'<div class="flex content-center" id="parent_start_{id_element}">']
     for _ in range(int(active_star)):
         elements.append('<i class ="rating__star rating_active"> </i>')

--- a/djf_surveys/validators.py
+++ b/djf_surveys/validators.py
@@ -1,22 +1,26 @@
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
 
+class RatingValidator(object):
+    def __init__(self, max):
+        self.max = max
 
-def validate_rating(value):
-    try:
-        rating = int(value)
-    except (TypeError, ValueError):
-        raise ValidationError(
-            _('%ss is not a number.' % value)
-        )
+    def __call__(self, value):
+        try:
+            rating = int(value)
+        except (TypeError, ValueError):
+            raise ValidationError(
+                _('%ss is not a number.' % value)
+            )
 
-    if rating > 5:
-        raise ValidationError(
-            _('Value cannot be greater than 5.')
-        )
+        if rating > self.max:
+            raise ValidationError(
+                _('Value cannot be greater than maximum allowed number of ratings.')
+            )
 
-    if rating < 1:
-        raise ValidationError(
-            _('Value cannot be less than 1.')
-        )
+        if rating < 1:
+            raise ValidationError(
+                _('Value cannot be less than 1.')
+            )
+
 

--- a/djf_surveys/widgets.py
+++ b/djf_surveys/widgets.py
@@ -15,7 +15,12 @@ class DateSurvey(forms.DateTimeInput):
 
 class RatingSurvey(forms.HiddenInput):
     template_name = 'djf_surveys/widgets/star_rating.html'
+    stars = 8
 
+    def get_context(self, name, value, attrs):
+        context = super().get_context(name, value, attrs)
+        context['widget']['num_ratings'] = self.num_ratings
+        return context
 
 class InlineChoiceField(forms.HiddenInput):
     template_name = 'djf_surveys/widgets/inline_choices.html'


### PR DESCRIPTION
This rather complicated pull request adds the possibility to change the number of ratings used by adding a new "Number of ratings" property to rating questions:
![image](https://github.com/irfanpule/django-form-surveys/assets/50527612/5af86a2e-3e58-4631-8811-c5ab8f50b006)


Internally it simply stores the number of ratings in the ```choices``` property of the question model as this was previously not used for rating questions. Simply reusing this property is IMO much simpler than creating a new model property just for the ratings.

The number of ratings displayed is then dynamically updated everywhere:
![image](https://github.com/irfanpule/django-form-surveys/assets/50527612/af15266b-b0da-4297-8b83-33c5652345cb)
![image](https://github.com/irfanpule/django-form-surveys/assets/50527612/09575797-dce9-452f-a0b9-0faadfa89113)

For future extensions one could think about storing json() encoded meta information in the choices field to bundle together more custom options - but I think that's a rather big change for future updates.

