### PR TITLE
Added possibility to prefill survey questions by url parameter

### DIFF
--- a/djf_surveys/views.py
+++ b/djf_surveys/views.py
@@ -54,21 +54,22 @@ class SurveyFormView(FormMixin, DetailView):
         context = self.get_context_data(object=self.object)
 
         # use url/get parameters as initial parameters
-        questions = Question.objects.filter(survey=self.object)
-        for param in request.GET.keys(): # loop over all GET parameters
-            for question in questions:
-                if question.key == param: # find corresponding question
-                    field_key = f"field_survey_{question.id}"
-                    if field_key in context["form"].field_names:
-                        if question.type_field == TYPE_FIELD.rating:
-                            if question.choices == None:
-                                question.choices = 5
-                            context["form"][field_key].field.initial = max(0,min(int(request.GET[param]), int(question.choices) - 1))
-                        elif question.type_field == TYPE_FIELD.multi_select:
-                            context["form"][field_key].field.initial = request.GET[param].split(',')
-                        else:
-                            context["form"][field_key].field.initial = request.GET[param]
-                    break
+        if 'create' in request.path:
+            questions = Question.objects.filter(survey=self.object)
+            for param in request.GET.keys(): # loop over all GET parameters
+                for question in questions:
+                    if question.key == param: # find corresponding question
+                        field_key = f"field_survey_{question.id}"
+                        if field_key in context["form"].field_names:
+                            if question.type_field == TYPE_FIELD.rating:
+                                if question.choices == None:
+                                    question.choices = 5
+                                context["form"][field_key].field.initial = max(0,min(int(request.GET[param]), int(question.choices) - 1))
+                            elif question.type_field == TYPE_FIELD.multi_select:
+                                context["form"][field_key].field.initial = request.GET[param].split(',')
+                            else:
+                                context["form"][field_key].field.initial = request.GET[param]
+                        break
 
         return self.render_to_response(context)
 

--- a/djf_surveys/views.py
+++ b/djf_surveys/views.py
@@ -10,7 +10,7 @@ from django.utils.decorators import method_decorator
 from django.shortcuts import redirect, get_object_or_404
 from django.contrib import messages
 
-from djf_surveys.models import Survey, UserAnswer
+from djf_surveys.models import Survey, UserAnswer, Question, TYPE_FIELD
 from djf_surveys.forms import CreateSurveyForm, EditSurveyForm
 from djf_surveys.mixin import ContextTitleMixin
 from djf_surveys import app_settings
@@ -48,6 +48,29 @@ class SurveyListView(ContextTitleMixin, UserPassesTestMixin, ListView):
 class SurveyFormView(FormMixin, DetailView):
     template_name = 'djf_surveys/form.html'
     success_url = reverse_lazy("djf_surveys:index")
+
+    def get(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        context = self.get_context_data(object=self.object)
+
+        # use url/get parameters as initial parameters
+        questions = Question.objects.filter(survey=self.object)
+        for param in request.GET.keys(): # loop over all GET parameters
+            for question in questions:
+                if question.key == param: # find corresponding question
+                    field_key = f"field_survey_{question.id}"
+                    if field_key in context["form"].field_names:
+                        if question.type_field == TYPE_FIELD.rating:
+                            if question.choices == None:
+                                question.choices = 5
+                            context["form"][field_key].field.initial = max(0,min(int(request.GET[param]), int(question.choices) - 1))
+                        elif question.type_field == TYPE_FIELD.multi_select:
+                            context["form"][field_key].field.initial = request.GET[param].split(',')
+                        else:
+                            context["form"][field_key].field.initial = request.GET[param]
+                    break
+
+        return self.render_to_response(context)
 
     def post(self, request, *args, **kwargs):
         form = self.get_form()


### PR DESCRIPTION
This change adds the possibility to prefill survey questions from an url parameter, e.g. 
```http://127.0.0.1:8000/create/get-parse-test/?label=ABCD```
will initialize the question with key ```label``` with the value ```ABCD```

The use case for this feature is if the surveys are linked from any other system where possibly some fields might be provided from the other system. Let's say a restaurant let's the user fill out a survey about the quality of the food and the survey has fields with keys ```restaurant_name``` and ```date_of_visit```, then the restaurant website could link to the survey as
```http://127.0.0.1:8000/create/food_survey/?restaurant_name=McDonalds&date_of_visit=01/01/2024``` to prefill those survey values.

I have tried to test it with all types of questions, e.g.
```http://127.0.0.1:8000/create/get-parse-test/?label=ABCD&number=44&radio=aaa&select=b&multi_select=b,c&text=ABC&url=test.com&email=test@test.de&rating=2&date=01/01/2024```
results in:
![image](https://github.com/irfanpule/django-form-surveys/assets/50527612/734d5676-adb2-4316-acfb-17358ed5f7ed)
