### PR TITLE
Clicking a survey in the survey list for anonymous users will use create instead of detail

### DIFF
--- a/djf_surveys/templates/djf_surveys/components/card_list_survey.html
+++ b/djf_surveys/templates/djf_surveys/components/card_list_survey.html
@@ -30,7 +30,7 @@
         {% endif %}
     </div>
 
-    <a class="relative block p-8 overflow-hidden border border-gray-100 rounded-lg bg-white" href="{% url 'djf_surveys:detail' survey.slug %}">
+    <a class="relative block p-8 overflow-hidden border border-gray-100 rounded-lg bg-white" href="{% if user.is_authenticated %}{% url 'djf_surveys:detail' survey.slug %}{% else %}{% url 'djf_surveys:create' survey.slug %}{% endif %}">
         <span class="absolute inset-x-0 bottom-0 h-2  bg-gradient-to-r from-green-300 via-blue-500 to-purple-600"></span>
         <div class="justify-between sm:flex">
             <div>


### PR DESCRIPTION
Changed that if non authenticated/anonymous users click a survey in the survey list they are taken to 'create' instead of 'detail' (which will not work without authentication)