### PR TITLE
Fixed Star Rating - 0 Default Value

### DIFF
--- a/djf_surveys/templates/djf_surveys/widgets/star_rating.html
+++ b/djf_surveys/templates/djf_surveys/widgets/star_rating.html
@@ -1,6 +1,6 @@
 {% load static djf_survey_tags %}
 
-<input type="{{ widget.type }}" name="{{ widget.name }}"{% if widget.value != None %} value="{{ widget.value }}"{% endif %}{% include "django/forms/widgets/attrs.html" %}>
+<input type="{{ widget.type }}" name="{{ widget.name }}"{% if widget.value != None %} value="{{ widget.value }}" {% else %} value="0" {% endif %}{% include "django/forms/widgets/attrs.html" %}>
 {% if widget.value != None %}
     {% create_star widget.value widget.attrs.id widget.num_ratings %}
 {% else %}


### PR DESCRIPTION
Through testing i noticed an issue regarding the Star Rating Field, when no star was selected, and the "Required" field, was disabled.

If you selected a random rating, and then unselected the stars you would get an error message, triggered by the Rating Field Validator, that "Value cannot be less than 0"
However if you submit the form without ever selecting a rating, the form will submit with no issues. This creates a "Blank" value in the DB Table, which breaks the Survey Dashboard page as the blank value cannot be converted to int

This happens because there is never set a value data var on the widget. Only when the executeRating function is run, which which first happens when you click on a star. This simple change, just adds the default value of 0, to the widget.